### PR TITLE
Migration: adapt repo-url for the deploy script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![Build Status](https://travis-ci.org/Orange-Foundation/edupi.svg?branch=master)](https://travis-ci.org/Orange-Foundation/edupi)
-[![Coverage Status](https://coveralls.io/repos/Orange-Foundation/edupi/badge.svg?branch=master)](https://coveralls.io/r/Orange-Foundation/edupi?branch=master)
+[![Coverage Status](https://coveralls.io/repos/Orange-Foundation/edupi/badge.svg?branch=master&service=github)](https://coveralls.io/github/Orange-Foundation/edupi?branch=master)
 
 # EduPi
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-[![Build Status](https://travis-ci.org/yuancheng2013/edupi.svg?branch=master)](https://travis-ci.org/yuancheng2013/edupi)
-[![Coverage Status](https://coveralls.io/repos/yuancheng2013/edupi/badge.svg?branch=master)](https://coveralls.io/r/yuancheng2013/edupi?branch=master)
+[![Build Status](https://travis-ci.org/Orange-Foundation/edupi.svg?branch=master)](https://travis-ci.org/Orange-Foundation/edupi)
+[![Coverage Status](https://coveralls.io/repos/Orange-Foundation/edupi/badge.svg?branch=master)](https://coveralls.io/r/Orange-Foundation/edupi?branch=master)
 
 # EduPi
 

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -18,7 +18,7 @@ Dependencies:
 Clone the project on your local machine, go into the project directory and you are ready to go:
 
 
-    $> git clone https://github.com/yuancheng2013/edupi.git
+    $> git clone https://github.com/Orange-Foundation/edupi.git
     $> cd edupi/deploy
 
 
@@ -59,7 +59,7 @@ By default, the command above will install the latest release from the release b
 
 If you want to install any other version, you can get the commit SHA1 code from Github, and append to the command.
 For example, `d9bdc37827cc360d618060ab8866a58572ca42da` is a commit for
-[`v1.4.1`](https://github.com/yuancheng2013/edupi/releases/tag/v1.4.1).
+[`v1.4.1`](https://github.com/Orange-Foundation/edupi/releases/tag/v1.4.1).
 You can install it by running:
 
     $> fab deploy_edupi:host=pi@RASPBERRY_IP,commit=d9bdc37827cc360d618060ab8866a58572ca42da
@@ -91,6 +91,13 @@ There is a default super user account created with this deployment script:
     user: pi
     password: raspberry
 
+**For developement**
+
+If you have forked edupi, you can deploy with your code after you pushed that on your github.
+
+    $> fab deploy_edupi:host=pi@RASPEBRRY_PI,commit=COMMIT_CODE,user=GITHUB_USER
+
+In this case, please always add your username in the command.
 
 ## Uninstall EduPi
 

--- a/deploy/fabfile.py
+++ b/deploy/fabfile.py
@@ -49,9 +49,9 @@ def config_hotspot():
     run('sudo reboot')
 
 
-def deploy_edupi(commit='origin/release'):
+def deploy_edupi(commit='origin/release', user='Orange-Foundation'):
     manager = EdupiDeployManager()
-    manager.deploy(commit)
+    manager.deploy(commit, user.strip())
 
 
 def uninstall_edupi(purge_data=False):
@@ -61,7 +61,7 @@ def uninstall_edupi(purge_data=False):
 
 def deploy_index_page():
     site_folder = '/home/%s/sites/www' % RASP_USER_NAME
-    repo_url = 'https://github.com/yuancheng2013/raspberry-index-page.git'
+    repo_url = 'https://github.com/Orange-Foundation/raspberry-index-page.git'
     # Nginx conf
     send_file('/etc/nginx/sites-enabled/%s' % PORTAL_SITE_NAME, mod='644')
 


### PR DESCRIPTION
* Add `user` specifying edupi's github repo for development purpose.
Usage example:

```
$> fab deploy_edupi:host=pi@192.168.1.40,commit=e3936c1565a35214997ef2b3de3f6dfe0a44e4a0,user=yuancheng2013
```