### PR TITLE
Added Python3.5 compatibility

### DIFF
--- a/cntapp/static/cntapp/custom/src/app.build.js
+++ b/cntapp/static/cntapp/custom/src/app.build.js
@@ -16,7 +16,7 @@
         'bootstrap_editable': '../../../../../libs/bower_components/x-editable/dist/bootstrap3-editable/js/bootstrap-editable',
         'bootstrap_table': '../../../../../libs/bower_components/bootstrap-table/src/bootstrap-table',
         'bootstrap_table_editable': '../../../../../libs/bower_components/bootstrap-table/src/extensions/editable/bootstrap-table-editable',
-        'text': '../../../../../libs/bower_components/requirejs-text/text',
+        'text': '../../../../../libs/bower_components/text/text',
         'dropzone': '../../../../../libs/bower_components/dropzone/dist/dropzone-amd-module',
         'i18n': '../../../../../libs/bower_components/i18next/i18next',
 

--- a/cntapp/static/cntapp/custom/src/main.js
+++ b/cntapp/static/cntapp/custom/src/main.js
@@ -11,7 +11,7 @@ require.config({
         'bootstrap_editable': '/static/x-editable/dist/bootstrap3-editable/js/bootstrap-editable',
         'bootstrap_table': '/static/bootstrap-table/src/bootstrap-table',
         'bootstrap_table_editable': '/static/bootstrap-table/src/extensions/editable/bootstrap-table-editable',
-        'text': '/static/requirejs-text/text',
+        'text': '/static/text/text',
         'dropzone': '/static/dropzone/dist/dropzone-amd-module',
         'i18n': '/static/i18next/i18next',
 

--- a/cntapp/static/cntapp/final/src/app.build.js
+++ b/cntapp/static/cntapp/final/src/app.build.js
@@ -13,7 +13,7 @@
         'underscore': '../../../../../libs/bower_components/underscore/underscore',
         'backbone': '../../../../../libs/bower_components/backbone/backbone',
         'bootstrap': '../../../../../libs/bower_components/bootstrap/dist/js/bootstrap',
-        'text': '../../../../../libs/bower_components/requirejs-text/text',
+        'text': '../../../../../libs/bower_components/text/text',
         'i18n': '../../../../../libs/bower_components/i18next/i18next',
 
         // shared modules

--- a/cntapp/static/cntapp/final/src/main.js
+++ b/cntapp/static/cntapp/final/src/main.js
@@ -8,7 +8,7 @@ require.config({
         'underscore': '/static/underscore/underscore',
         'backbone': '/static/backbone/backbone',
         'bootstrap': '/static/bootstrap/dist/js/bootstrap',
-        'text': '/static/requirejs-text/text',
+        'text': '/static/text/text',
         'i18n': '/static/i18next/i18next',
 
         // shared modules

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
-Django==1.7.4
+Django==1.8.19
 gunicorn==19.3.0
 djangorestframework==3.1.1
-django-bower==5.0.3
+django-bower==5.2.0
 Pillow==2.8.1
 Wand==0.4.0
 django-imagekit==3.2.6


### PR DESCRIPTION
- Updated to Django 1.8.19 which supports python 3.5
- Updated to django-bower 5.2.0 which works with Django 1.8
- Fixed paths to `require-text` dependency script